### PR TITLE
Add MPEG-1 support

### DIFF
--- a/R/saving.R
+++ b/R/saving.R
@@ -63,6 +63,9 @@ animation_saver <- function(saver, filename, mime_type = NULL) {
                  mp4 = animation::saveVideo,
                  webm = animation::saveVideo,
                  avi = animation::saveVideo,
+                 mpeg = function(expr, filename, ...) {
+                   animation::saveVideo(expr, filename,
+                                        other.opts = ifelse(animation::ani.options('interval') >= 1/24, "-r 24", "-r 30")) },
                  html = function(expr, filename, ...) animation::saveHTML(expr, htmlfile = filename, ...),
                  tex = function(expr, filename, ...) animation::saveLatex(expr, latex.filename = filename, ...),
                  pdf = function(expr, filename, ...) animation::saveLatex(expr, latex.filename = gsub("pdf$", "tex", filename, perl = TRUE)),
@@ -75,6 +78,7 @@ animation_saver <- function(saver, filename, mime_type = NULL) {
   # for those that can be viewed in RStudio, save the mime_type
   mime_types <- list(gif = "image/gif",
                      mp4 = "video/mp4",
+                     mpeg = "video/mpeg",
                      webm = "video/webm",
                      avi = "video/avi")
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -80,6 +80,7 @@ You can also save the animation to a file, such as an GIF, video, or an animated
 ```{r eval = FALSE}
 gg_animate(p, "output.gif")
 gg_animate(p, "output.mp4")
+gg_animate(p, "output.mpeg")
 gg_animate(p, "output.swf")
 gg_animate(p, "output.html")
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can also save the animation to a file, such as an GIF, video, or an animated
 ```r
 gg_animate(p, "output.gif")
 gg_animate(p, "output.mp4")
+gg_animate(p, "output.mpeg")
 gg_animate(p, "output.swf")
 gg_animate(p, "output.html")
 ```

--- a/tests/testthat/test-savers.R
+++ b/tests/testthat/test-savers.R
@@ -18,8 +18,8 @@ test_that("We can create an animated GIF", {
 })
 
 
-test_that("We can create an animated mp4 or avi", {
-  for (ext in c("mp4", "avi")) {
+test_that("We can create an animated mp4, avi or mpeg", {
+  for (ext in c("mp4", "avi", "mpeg")) {
     s <- gg_animate_save(gg_animate(p), saver = ext)
     expect_is(s, "gg_animate")
 


### PR DESCRIPTION
MPEG-1 is the most cross- and back-compatible format across OSX, Windows, and importantly, PPT.  This adds MPEG-1 support. A little special handling is required as MPEG-1 only allows frame rates of 24 and 30. 
