### PR TITLE
Added ftext call - Maps character vector to frame number

### DIFF
--- a/R/gganimate.R
+++ b/R/gganimate.R
@@ -97,18 +97,20 @@ gganimate <- function(p = last_plot(), filename = NULL, ftext = NULL,
     # title plot according to frame
     if (title_frame) {
       if (!is.null(b$plot$labels$title)) {
-        b$plot$labels$title <- paste(b$plot$labels$title, f)
-      } else {
+        b$plot$labels$title <- paste(b$plot$labels$title,
+                                     f)
+      }
+      else if (!is.null(ftext)){
+        if (length(ftext) != length(seq_along(b$data))){
+          stop("Character vector length must equal number of unique frames")
+        } else {
+          b$plot$labels$title <- ftext[f]
+        }
+      }
+      else {
         b$plot$labels$title <- f
       }
     }
-    if (!is.null(ftext)){
-      if (length(ftext) != length(f)){
-        stop("Character vector length must equal number of unique frames")
-      }
-      b$plot$labels$title <- ftext[f]
-    }
-
     b
   })
 

--- a/R/gganimate.R
+++ b/R/gganimate.R
@@ -18,6 +18,8 @@
 #' filename extension.
 #' @param title_frame Whether to title each image with the current \code{frame} value.
 #' The value is appended on to any existing title.
+#' @param ftext Specify a character vector of frame titles to be mapped to unique frame
+#' values.
 #' @param ... If saving to a file, extra arguments to pass along to the animation
 #' saving function (to \code{saveVideo}/\code{saveGIF}/etc).
 #'
@@ -54,7 +56,7 @@
 #'
 #'
 #' @export
-gganimate <- function(p = last_plot(), filename = NULL,
+gganimate <- function(p = last_plot(), filename = NULL, ftext = NULL,
                        saver = NULL, title_frame = TRUE, ...) {
   if (is.null(p)) {
     stop("no plot to animate")
@@ -99,6 +101,12 @@ gganimate <- function(p = last_plot(), filename = NULL,
       } else {
         b$plot$labels$title <- f
       }
+    }
+    if (!is.null(ftext)){
+      if (length(ftext) != length(f)){
+        stop("Character vector length must equal number of unique frames")
+      }
+      b$plot$labels$title <- ftext[f]
     }
 
     b


### PR DESCRIPTION
After doing a bit a searching, I was unable to find a method to title frames with strings without losing their specified order in the final animation. This change maps a specified character vector to a vector of unique frame IDs, which allows for ordering of frame title strings.