### PR TITLE
Added an `overwrite` option to `file_renderer`

### DIFF
--- a/R/renderers.R
+++ b/R/renderers.R
@@ -18,6 +18,7 @@
 #'
 #' @param dir The directory to copy the frames to
 #' @param prefix The filename prefix to use for the image files
+#' @param overwrite Logical. If TRUE, existing files will be overwritten.
 #'
 #' @return The provided renderers are factory functions that returns a new function
 #' that take `frames` and `fps` as arguments, the former being a character
@@ -42,10 +43,10 @@ magick_renderer <- function() {
 }
 #' @rdname renderers
 #' @export
-file_renderer <- function(dir = '~', prefix = 'gganim_plot') {
+file_renderer <- function(dir = '~', prefix = 'gganim_plot', overwrite = FALSE) {
   function(frames, fps) {
     new_names <- file.path(dir, sub('gganim_plot', prefix, basename(frames)))
-    file.copy(frames, new_names)
+    file.copy(frames, new_names, overwrite = overwrite)
     invisible(new_names)
   }
 }


### PR DESCRIPTION
Added an extra option to `file_renderer`, called `overwrite` (boolean).

At present when using `file_renderer` the function falls silently, and does not write any files if there are existing files on disk with the same name.

This PR implements a way to force overwriting existing files with the same name. The argument is simply passed to `copy.file`. Useful when you are tweaking a visualization obviously.

The default value of the `overwrite` option is `FALSE`, for consistency with the existing function. That said, IMO the function should return a warning when no file is written because of existing files.