### PR TITLE
Quick fix for different color spellings for shadow_* based methods

### DIFF
--- a/R/shadow-mark.R
+++ b/R/shadow-mark.R
@@ -16,6 +16,7 @@
 #' @importFrom rlang quos
 shadow_mark <- function(past = TRUE, future = FALSE, ..., exclude_layer = NULL) {
   dots <- quos(...)
+  names(dots) <- sub('color', 'colour', names(dots))
   ggproto(NULL, ShadowMark,
     exclude_layer = exclude_layer,
     params = list(

--- a/R/shadow-trail.R
+++ b/R/shadow-trail.R
@@ -21,6 +21,7 @@
 #' @importFrom rlang quos
 shadow_trail <- function(distance = 0.05, max_frames = Inf, ..., exclude_layer = NULL) {
   dots <- quos(...)
+  names(dots) <- sub('color', 'colour', names(dots))
   ggproto(NULL, ShadowTrail,
           exclude_layer = exclude_layer,
           params = list(


### PR DESCRIPTION
Originally forked the repo to write some examples for as many functions as I can, but found this small bug where shadow_mark and shadow_trail don't work for 'color' but do for 'colour' when passed as an argument. I don't know how ggproto objects work and this color-colour thing shouldn't happen but it didn't work for me :( 

A simple ```sub()``` call for ```names(dots)``` did the trick! 