### PR TITLE
overwrite existing files in anim_save

### DIFF
--- a/R/anim_save.R
+++ b/R/anim_save.R
@@ -38,7 +38,7 @@ save_animation.default <- function(animation, file) {
 }
 #' @export
 save_animation.gif_image <- function(animation, file) {
-  file.copy(animation, file)
+  file.copy(animation, file, overwrite = TRUE)
   invisible(NULL)
 }
 #' @export

--- a/tests/testthat/test-anim_save.R
+++ b/tests/testthat/test-anim_save.R
@@ -1,0 +1,26 @@
+context("test-anim_save")
+
+test_that("anim_save overwrites existing files", {
+  p <- ggplot(airquality, aes(Day, Temp)) +
+    geom_line(color = 'red', size = 1) +
+    transition_time(Month)
+
+  capture.output({
+    a1 <- animate(p, nframes = 2)
+    a2 <- animate(p, nframes = 3)
+  })
+
+  tf <- tempfile()
+  on.exit(unlink(tf))
+
+  anim_save(a1, file = tf)
+
+  frames_1 <- nrow(magick::image_info(magick::image_read(tf)))
+  expect_equal(frames_1, 2)
+
+  anim_save(a2, file = tf)
+
+  frames_2 <- nrow(magick::image_info(magick::image_read(tf)))
+
+  expect_equal(frames_2, 3)
+})


### PR DESCRIPTION
`file.copy()` defaults to overwrite = FALSE but does not issue an error
or warning if the file exists.

Fixes #116