### PR TITLE
Make sure the figure dir exists before copying the gif

### DIFF
--- a/R/renderers.R
+++ b/R/renderers.R
@@ -190,6 +190,7 @@ print.gif_image <- function(x, ...) {
 #' @export
 knit_print.gif_image <- function(x, ...) {
   knitr_path <- knitr::fig_path('.gif')
+  dir.create(dirname(knitr_path), showWarnings = FALSE, recursive = TRUE)
   file.copy(x, knitr_path, overwrite = TRUE)
   knitr::knit_print(knitr::include_graphics(knitr_path))
 }


### PR DESCRIPTION
If you don't create the dir first, `file.copy()` will fail. Reprex:

````
---
title: "Untitled"
output: html_document
---

```{r}
library(ggplot2)
library(gganimate)

ggplot(mtcars, aes(factor(cyl), mpg)) + 
  geom_boxplot() + 
  # Here comes the gganimate code
  transition_states(
    gear,
    transition_length = 2,
    state_length = 1
  ) +
  enter_fade() + 
  exit_shrink() +
  ease_aes('sine-in-out')
```
````