### PR TITLE
fixed minor typos in documentation

### DIFF
--- a/R/animate.R
+++ b/R/animate.R
@@ -6,7 +6,7 @@
 #' time and can be any two combination of `nframes`, `fps`, and `length`.
 #' Rendering is happening in discrete time units. This means that any event in
 #' the animation is rounded of to the nearest frame (e.g. entering will always
-#' take a whole number of frames). This means that rounding artefacts are
+#' take a whole number of frames). This means that rounding artifacts are
 #' possible when only rendering few frames. To avoid this you can increase the
 #' `detail` argument. `detail` will get multiplied to `nframes` and the
 #' resulting number of frames will get calculated, but only `nframes` evenly

--- a/R/renderers.R
+++ b/R/renderers.R
@@ -4,7 +4,7 @@
 #' assemble them into an animation. `gganimate` provide a range of renderers
 #' but it is also possible to provide your own, if the supplied ones are lacking
 #' in any way. A renderer is given as argument to [animate()]/print() and
-#' recieves the paths to the individual frames once they have been created.
+#' receives the paths to the individual frames once they have been created.
 #'
 #' @details It is possible to provide your own renderer function providing that it
 #' matches the required signature (`frames` and `fps` argument). The return

--- a/R/shadow-null.R
+++ b/R/shadow-null.R
@@ -1,4 +1,4 @@
-#' A non-existant shadow
+#' A non-existent shadow
 #'
 #' This is the default shadow that simply doesn't show anything other than the
 #' data for the current frame.

--- a/R/shadow-wake.R
+++ b/R/shadow-wake.R
@@ -1,4 +1,4 @@
-#' Show preceeding frames with gradual falloff
+#' Show preceding frames with gradual falloff
 #'
 #' This shadow is meant to draw a small wake after data by showing the latest
 #' frames up to the current. You can choose to gradually diminish the size

--- a/R/transition-filter.R
+++ b/R/transition-filter.R
@@ -26,7 +26,7 @@ NULL
 #' `transition_filter` makes the following variables available for string
 #' literal interpretation:
 #'
-#' - **transitioning** is a booloean indicating whether the frame is part of the
+#' - **transitioning** is a boolean indicating whether the frame is part of the
 #'   transitioning phase
 #' - **previous_filter** The name of the last filter the animation was at
 #' - **closest_filter** The name of the filter closest to this frame

--- a/R/transition-layers.R
+++ b/R/transition-layers.R
@@ -11,7 +11,7 @@ NULL
 #' one enters
 #' @param transition_length The proportional time to use for the entrance of a
 #' new layer
-#' @param keep_layers Should layers be kept on screen after they have appeeared
+#' @param keep_layers Should layers be kept on screen after they have appeared
 #' or transition out when a new layer enters
 #' @param from_blank Should the first layer transition in or be present on the
 #' onset of the animation
@@ -22,7 +22,7 @@ NULL
 #' `transition_layers` makes the following variables available for string
 #' literal interpretation:
 #'
-#' - **transitioning** is a booloean indicating whether the frame is part of the
+#' - **transitioning** is a boolean indicating whether the frame is part of the
 #'   transitioning phase
 #' - **previous_layer** The name of the last layer the animation was showing
 #' - **closest_layer** The name of the layer the animation is closest to showing

--- a/R/transition-states.R
+++ b/R/transition-states.R
@@ -22,7 +22,7 @@ NULL
 #' `transition_states` makes the following variables available for string
 #' literal interpretation:
 #'
-#' - **transitioning** is a booloean indicating whether the frame is part of the
+#' - **transitioning** is a boolean indicating whether the frame is part of the
 #'   transitioning phase
 #' - **previous_state** The name of the last state the animation was at
 #' - **closest_state** The name of the state closest to this frame

--- a/R/transmute-.R
+++ b/R/transmute-.R
@@ -26,7 +26,7 @@
 #' in/out during the transition.
 #'
 #' **grow**/**shrink** will set the elements to zero size making them gradually
-#' grow into / shrink out of existance. Zero size depends on the type of layer,
+#' grow into / shrink out of existence. Zero size depends on the type of layer,
 #' e.g. polygons/paths will have all their points set to the mean, while points
 #' will have size/stroke set to zero.
 #'

--- a/R/view-step.R
+++ b/R/view-step.R
@@ -7,7 +7,7 @@
 #'
 #' @param pause_length The relative length the view will be kept static. Will
 #' be recycled to match the number of steps
-#' @param step_length The relative length the view will use to transtion to the
+#' @param step_length The relative length the view will use to transition to the
 #' new position. Will be recycled to match the number of steps
 #' @param nsteps The number of steps. If `NULL` it will be set to the max length
 #' of `pause_length` or `step_length`

--- a/man/animate.Rd
+++ b/man/animate.Rd
@@ -50,7 +50,7 @@ nature of the animation is dependent on the renderer, but defaults to using
 time and can be any two combination of \code{nframes}, \code{fps}, and \code{length}.
 Rendering is happening in discrete time units. This means that any event in
 the animation is rounded of to the nearest frame (e.g. entering will always
-take a whole number of frames). This means that rounding artefacts are
+take a whole number of frames). This means that rounding artifacts are
 possible when only rendering few frames. To avoid this you can increase the
 \code{detail} argument. \code{detail} will get multiplied to \code{nframes} and the
 resulting number of frames will get calculated, but only \code{nframes} evenly

--- a/man/enter_exit.Rd
+++ b/man/enter_exit.Rd
@@ -62,7 +62,7 @@ start or end of the transition.
 in/out during the transition.
 
 \strong{grow}/\strong{shrink} will set the elements to zero size making them gradually
-grow into / shrink out of existance. Zero size depends on the type of layer,
+grow into / shrink out of existence. Zero size depends on the type of layer,
 e.g. polygons/paths will have all their points set to the mean, while points
 will have size/stroke set to zero.
 }

--- a/man/renderers.Rd
+++ b/man/renderers.Rd
@@ -64,7 +64,7 @@ The purpose of the renderer function is to take a list of image files and
 assemble them into an animation. \code{gganimate} provide a range of renderers
 but it is also possible to provide your own, if the supplied ones are lacking
 in any way. A renderer is given as argument to \code{\link[=animate]{animate()}}/print() and
-recieves the paths to the individual frames once they have been created.
+receives the paths to the individual frames once they have been created.
 }
 \details{
 It is possible to provide your own renderer function providing that it

--- a/man/shadow_mark.Rd
+++ b/man/shadow_mark.Rd
@@ -26,7 +26,7 @@ and/or future raw data can be shown and styled as you want.
 # Adding a grouping variable in a transition call prior to calling `shadow_mark()` will
 # allow transitioning through different states in time.
 
-p1 <- ggplot(airquality, aes(Day, Time)) +
+p1 <- ggplot(airquality, aes(Day, Temp)) +
   geom_line(color = 'red', size = 1) +
   transition_time(Month) +
   shadow_mark(colour = 'black', size = 0.75)
@@ -35,7 +35,7 @@ p1 <- ggplot(airquality, aes(Day, Time)) +
 
 # Add a future = TRUE argument to show data later in the animation.
 
-p2 <- ggplot(airquality, aes(Day, Time)) +
+p2 <- ggplot(airquality, aes(Day, Temp)) +
   geom_line(color = 'red', size = 1) +
   transition_time(Month) +
   shadow_mark(color = 'black', size = 0.75, past = FALSE, future = TRUE)

--- a/man/shadow_null.Rd
+++ b/man/shadow_null.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/shadow-null.R
 \name{shadow_null}
 \alias{shadow_null}
-\title{A non-existant shadow}
+\title{A non-existent shadow}
 \usage{
 shadow_null()
 }

--- a/man/shadow_wake.Rd
+++ b/man/shadow_wake.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/shadow-wake.R
 \name{shadow_wake}
 \alias{shadow_wake}
-\title{Show preceeding frames with gradual falloff}
+\title{Show preceding frames with gradual falloff}
 \usage{
 shadow_wake(wake_length, size = TRUE, alpha = TRUE,
   falloff = "cubic-in", wrap = TRUE, exclude_layer = NULL,

--- a/man/transition_components.Rd
+++ b/man/transition_components.Rd
@@ -22,7 +22,7 @@ exit transitions. Defaults to 0}
 }
 \description{
 This transition allows individual visual components to define their own
-"life-cycle". This means that the final animation will not have any commen
+"life-cycle". This means that the final animation will not have any common
 "state" and "transition" phase as any component can be moving or static at
 any point in time.
 }

--- a/man/transition_filter.Rd
+++ b/man/transition_filter.Rd
@@ -37,7 +37,7 @@ kept the enter function will have no effect.
 \code{transition_filter} makes the following variables available for string
 literal interpretation:
 \itemize{
-\item \strong{transitioning} is a booloean indicating whether the frame is part of the
+\item \strong{transitioning} is a boolean indicating whether the frame is part of the
 transitioning phase
 \item \strong{previous_filter} The name of the last filter the animation was at
 \item \strong{closest_filter} The name of the filter closest to this frame

--- a/man/transition_layers.Rd
+++ b/man/transition_layers.Rd
@@ -14,7 +14,7 @@ one enters}
 \item{transition_length}{The proportional time to use for the entrance of a
 new layer}
 
-\item{keep_layers}{Should layers be kept on screen after they have appeeared
+\item{keep_layers}{Should layers be kept on screen after they have appeared
 or transition out when a new layer enters}
 
 \item{from_blank}{Should the first layer transition in or be present on the
@@ -33,7 +33,7 @@ but they can also be set to be removed as the next layer enters.
 \code{transition_layers} makes the following variables available for string
 literal interpretation:
 \itemize{
-\item \strong{transitioning} is a booloean indicating whether the frame is part of the
+\item \strong{transitioning} is a boolean indicating whether the frame is part of the
 transitioning phase
 \item \strong{previous_layer} The name of the last layer the animation was showing
 \item \strong{closest_layer} The name of the layer the animation is closest to showing

--- a/man/transition_states.Rd
+++ b/man/transition_states.Rd
@@ -31,7 +31,7 @@ during the animation (again, mimicking \code{facet_wrap}).
 \code{transition_states} makes the following variables available for string
 literal interpretation:
 \itemize{
-\item \strong{transitioning} is a booloean indicating whether the frame is part of the
+\item \strong{transitioning} is a boolean indicating whether the frame is part of the
 transitioning phase
 \item \strong{previous_state} The name of the last state the animation was at
 \item \strong{closest_state} The name of the state closest to this frame

--- a/man/view_step.Rd
+++ b/man/view_step.Rd
@@ -20,7 +20,7 @@ view_step_manual(pause_length, step_length, xmin, xmax, ymin, ymax,
 \item{pause_length}{The relative length the view will be kept static. Will
 be recycled to match the number of steps}
 
-\item{step_length}{The relative length the view will use to transtion to the
+\item{step_length}{The relative length the view will use to transition to the
 new position. Will be recycled to match the number of steps}
 
 \item{nsteps}{The number of steps. If \code{NULL} it will be set to the max length

--- a/man/view_zoom.Rd
+++ b/man/view_zoom.Rd
@@ -18,7 +18,7 @@ view_zoom_manual(pause_length, step_length, xmin, xmax, ymin, ymax,
 \item{pause_length}{The relative length the view will be kept static. Will
 be recycled to match the number of steps}
 
-\item{step_length}{The relative length the view will use to transtion to the
+\item{step_length}{The relative length the view will use to transition to the
 new position. Will be recycled to match the number of steps}
 
 \item{nsteps}{The number of steps. If \code{NULL} it will be set to the max length


### PR DESCRIPTION
Thanks for this awesome package! Please consider this small PR to fix minor misspellings in the documentation. 