### PR TITLE
`autoplay` parameter in `knit_print.video_file()`

### DIFF
--- a/R/renderers.R
+++ b/R/renderers.R
@@ -342,7 +342,13 @@ print.video_file <- function(x, width = NULL, ...) {
 #' @export
 knit_print.video_file <- function(x, options, ...) {
   if (grepl('\\.(mp4)|(webm)|(ogg)$', x, ignore.case = TRUE)) {
-    knitr::knit_print(htmltools::browsable(as_html_video(x, width = get_chunk_width(options))), options, ...)
+    knitr::knit_print(
+      htmltools::browsable(
+        as_html_video(x, width = get_chunk_width(options), autoplay = get_chunk_autoplay(options))
+      ), 
+      options, 
+      ...
+    )
   } else {
     warning('The video format doesn\'t support HTML', call. = FALSE)
     invisible(NULL)
@@ -352,7 +358,7 @@ knit_print.video_file <- function(x, options, ...) {
 split.video_file <- function(x, f, drop = FALSE, ...) {
   stop('video_file objects does not support splitting', call. = FALSE)
 }
-as_html_video <- function(x, width = NULL) {
+as_html_video <- function(x, width = NULL, autoplay = TRUE) {
   if (!requireNamespace("base64enc", quietly = TRUE)) {
     stop('The base64enc package is required for showing video')
   }
@@ -361,14 +367,14 @@ as_html_video <- function(x, width = NULL) {
   }
   format <- tolower(sub('^.*\\.(.+)$', '\\1', x))
   htmltools::HTML(paste0(
-    '<video controls autoplay',
+    '<video controls', if (autoplay) ' autoplay' else '',
     if (is.null(width)) '' else paste0(' width="', width, '"'),
-    '><source src="data:video/',
-    format,
-    ';base64,',
-    base64enc::base64encode(x),
-    '" type="video/mp4"></video>'
+    '>',
+    '<source src="data:video/', format, ';base64,', base64enc::base64encode(x), '" type="video/mp4"></video>'
   ))
+}
+get_chunk_autoplay <- function(options) {
+  options$autoplay %||% TRUE
 }
 #' Wrap an image sprite for easy handling
 #'


### PR DESCRIPTION
Change in `knit_print.video_file()` and `as_html_video()` to allow deactivation of autoplay for video integration in HTML.
Add `get_chunk_autoplay()` to allow `autoplay` in general `options()` and to retrieve that value.