### PR TITLE
shiny progress support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ matrix:
     after_success:
     - Rscript -e 'covr::codecov()'
 
-    deploy:
-      provider: script
-      script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE, lazy = FALSE, run_dont_run = FALSE)'
-      skip_cleanup: true
+    #deploy:
+    #  provider: script
+    #  script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE, lazy = FALSE, run_dont_run = FALSE)'
+    #  skip_cleanup: true
   - r: oldrel

--- a/R/animate.R
+++ b/R/animate.R
@@ -28,6 +28,7 @@
 #' @param start_pause,end_pause Number of times to repeat the first and last
 #' frame in the animation (default is `0` for both)
 #' @param rewind Should the animation roll back in the end (default `FALSE`)
+#' @param update_progress function to called as each frame is rendered
 #' @param ... Arguments passed on to the device
 #'
 #' @return The return value of the [renderer][renderers] function
@@ -238,7 +239,7 @@ prerender <- function(plot, nframes) {
 # Draw each frame as an image based on a specified device
 # Returns a data.frame of frame metadata with image location in frame_source
 # column
-draw_frames <- function(plot, frames, device, ref_frame, ...) {
+draw_frames <- function(plot, frames, device, ref_frame, update_progress = NULL, ...) {
   stream <- device == 'current'
 
   dims <- tryCatch(
@@ -296,6 +297,16 @@ draw_frames <- function(plot, frames, device, ref_frame, ...) {
 
     rate <- i/as.double(Sys.time() - start, units = 'secs')
     if (is.nan(rate)) rate <- 0
+    
+    # send update to shiny progress
+    if(is.function(update_progress)) {
+      frames_left <- length(frames) - i
+      projected_secs <- as.difftime(frames_left / rate, units = "secs")
+      eta <- vague_dt(projected_secs, format = "terse")
+      detail <- paste0("at ", format(rate, digits = 2), " fps ~ eta: ", eta)
+      update_progress(detail)
+    }
+
     rate <- format(rate, digits = 2)
     pb$tick(tokens = list(fps = rate))
 


### PR DESCRIPTION
Added support for shiny progress indicator based on the [RStudio complex example](https://shiny.rstudio.com/articles/progress.html#a-more-complex-progress-example). This pull request directly addresses issue #305 and partially addresses issue #272.

Comments were used in the travis yaml to avoid a pull-irrelevant build error involving deployment keys back to Github. I guess this change also resulted in the codecov errors. These changes can and should be ignored.

Progress message and detail were coded to best match the `progress::progress_bar` message using `prettyunits::vague_dt()`, but the decision to include `prettyunits` as a dependency is left up for debate. As it stands now, the user will have to `library(prettyunits)` in their app code to make this work.

This solution also requires the length of the progress bar in frames to be determined and set when making the `shiny::Progress` object and this value should also be passed to `annimate()`.

Example app:

```
library(gapminder)
library(gganimate)
library(ggplot2)
library(prettyunits)
library(shiny)

ui <- fluidPage(
  imageOutput("plot_image")
)

server <- function(input, output) {
  
  output$plot_image <- renderImage({
    
    # as per https://shiny.rstudio.com/articles/progress.html#a-more-complex-progress-example
    # but set max value to pre-determined total frame count
    progress <- shiny::Progress$new(max = 100)
    progress$set(message = "Rendering", value = 0)
    on.exit(progress$close())
    
    updateShinyProgress <- function(detail) {    
      progress$inc(1, detail = detail)
    }
    
    outfile <- tempfile(fileext='.gif')
    
    p <- ggplot(gapminder, aes(gdpPercap, lifeExp, size = pop, colour = country)) +
      geom_point(alpha = 0.7, show.legend = FALSE) +
      scale_colour_manual(values = country_colors) +
      scale_size(range = c(2, 12)) +
      scale_x_log10() +
      facet_wrap(~continent) +
      labs(title = 'Year: {frame_time}', x = 'GDP per capita', y = 'life expectancy') +
      transition_time(year) +
      ease_aes('linear')
    
    # use animate() to control nframes and pass shiny progress update function
    anim_save("outfile.gif", animate(p, nframes = 100, update_progress = updateShinyProgress))
    
    list(src = "outfile.gif",
         contentType = 'image/gif', 
         width = 400,
         height = 400,
         alt = "This is alternate text"
    )}, deleteFile = TRUE)
}

shinyApp(ui, server)
```
