### PR TITLE
Use the specified ffmpeg path when detecting format

### DIFF
--- a/R/renderers.R
+++ b/R/renderers.R
@@ -165,7 +165,7 @@ ffmpeg_renderer <- function(format = 'auto', ffmpeg = NULL, options = list(pix_f
   if (!has_ffmpeg(ffmpeg)) stop('The ffmpeg library is not available at the specified location', call. = FALSE)
   if (format == 'auto') {
     format <- if (.Platform$GUI == "RStudio" &&
-                  any(grepl('--enable-libvpx', system2('ffmpeg', '-version', stdout = TRUE)))) {
+                  any(grepl('--enable-libvpx', system2(ffmpeg, '-version', stdout = TRUE)))) {
       "webm"
     } else {
       "mp4"


### PR DESCRIPTION
Specifying the ffmpeg path in ffmpeg_renderer() will fail, because the format auto-detection still uses the hardcoded `ffmpeg` path.