### PR TITLE
Allow user path to ffmpeg.exe with "auto" format

### DIFF
--- a/R/renderers.R
+++ b/R/renderers.R
@@ -165,7 +165,7 @@ ffmpeg_renderer <- function(format = 'auto', ffmpeg = NULL, options = list(pix_f
   if (!has_ffmpeg(ffmpeg)) stop('The ffmpeg library is not available at the specified location', call. = FALSE)
   if (format == 'auto') {
     format <- if (.Platform$GUI == "RStudio" &&
-                  any(grepl('--enable-libvpx', system2('ffmpeg', '-version', stdout = TRUE)))) {
+                  any(grepl('--enable-libvpx', system2(ffmpeg, '-version', stdout = TRUE)))) {
       "webm"
     } else {
       "mp4"


### PR DESCRIPTION
When `format = "auto"`, the `system2` call is hard-coded to use the ffmpeg executable on the search path. 

This pull request removes that restriction and allows a custom path to the ffmpeg executable.