### PR TITLE
Remove plyr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Imports: stringi,
     rlang,
     glue,
     progress,
-    plyr,
     scales,
     grDevices,
     utils

--- a/R/ggplot2_reimpl.R
+++ b/R/ggplot2_reimpl.R
@@ -11,7 +11,7 @@ scales_transform_df <- function(scales, df) {
 
   transformed <- unlist(lapply(scales$scales, function(s) s$transform_df(df = df)),
                         recursive = FALSE)
-  plyr::quickdf(c(transformed, df[setdiff(names(df), names(transformed))]))
+  ggplot2:::new_data_frame(c(transformed, df[setdiff(names(df), names(transformed))]))
 }
 empty <- function(df) {
   is.null(df) || nrow(df) == 0 || ncol(df) == 0
@@ -50,7 +50,7 @@ scales_map_df <- function(scales, df) {
 
   mapped <- unlist(lapply(scales$scales, function(scale) scale$map_df(df = df)), recursive = FALSE)
 
-  plyr::quickdf(c(mapped, df[setdiff(names(df), names(mapped))]))
+  ggplot2:::new_data_frame(c(mapped, df[setdiff(names(df), names(mapped))]))
 }
 is.waive <- function(x) inherits(x, 'waiver')
 


### PR DESCRIPTION
Removed the plyr dependency by substituting `quickdf` with `ggplot2:::new_data_frame`

Note that this generates a NOTE since `new_data_frame` is unexported. I thought I'd still open the PR on the off chance you were interested in making that an exported function from ggplot2. No worries if you'd rather not change this right now. 