### PR TITLE
animate documentation: Add details

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: TRUE
 VignetteBuilder: knitr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)
 URL: https://gganimate.com, https://github.com/thomasp85/gganimate
 BugReports: https://github.com/thomasp85/gganimate/issues

--- a/R/animate.R
+++ b/R/animate.R
@@ -28,7 +28,8 @@
 #' @param start_pause,end_pause Number of times to repeat the first and last
 #' frame in the animation (default is `0` for both)
 #' @param rewind Should the animation roll back in the end (default `FALSE`)
-#' @param ... Arguments passed on to the device
+#' @param ... Arguments passed on to the device.
+#' For available device arguments, see [grDevices::png()] or [grDevices::svg()]
 #'
 #' @return The return value of the [renderer][renderers] function
 #'
@@ -104,6 +105,9 @@
 #'
 #' # Use a different renderer
 #' animate(anim, renderer = file_renderer('~/animation/'))[1:6]
+#'
+#' # Specify device dimensions and/or resolution
+#' animate(anim, height = 2, width = 3, units = "in", res = 150)
 #' }
 #'
 animate <- function(plot, ...) {

--- a/man/animate.Rd
+++ b/man/animate.Rd
@@ -31,7 +31,8 @@ knit_print.gganim(x, options, ...)
 \arguments{
 \item{plot, x}{A \code{gganim} object}
 
-\item{...}{Arguments passed on to the device}
+\item{...}{Arguments passed on to the device.
+For available device arguments, see \code{\link[grDevices:png]{grDevices::png()}} or \code{\link[grDevices:svg]{grDevices::svg()}}}
 
 \item{nframes}{The number of frames to render (default \code{100})}
 
@@ -148,6 +149,9 @@ animate(anim, nframes = 100, end_pause = 10, rewind = TRUE)
 
 # Use a different renderer
 animate(anim, renderer = file_renderer('~/animation/'))[1:6]
+
+# Specify device dimensions and/or resolution
+animate(anim, height = 2, width = 3, units = "in", res = 150)
 }
 
 }


### PR DESCRIPTION
added details to specify device dimensions. Based on [this SO thread](https://stackoverflow.com/questions/49058567/define-size-for-gif-created-by-gganimate-change-dimension-resolution/61763614#61763614) **with 8k views** and [this comment](https://github.com/thomasp85/gganimate/issues/96#issuecomment-561517878) with 9 upvotes, this seems a justified addition to the documentation. 