### PR TITLE
Bug fix: handling of NAs in tranasition_filter

### DIFF
--- a/R/transition-filter.R
+++ b/R/transition-filter.R
@@ -215,7 +215,7 @@ assign_filters <- function(data, filters, after = FALSE, row_vars = NULL) {
       filter
     }))
     if (all(row_filter)) return(numeric(0))
-    apply(row_filter, 2, function(x) if (!any(x)) '0' else paste(which(x), collapse = '-'))
+    apply(row_filter, 2, function(x) if (!any(x, na.rm = TRUE)) '0' else paste(which(x), collapse = '-'))
   })
   if (after) {
     Map(function(new_f, old_f) paste0(old_f, '-', new_f), new_f = row_filters, old_f = row_vars$filter)


### PR DESCRIPTION
## PROBLEM:
When there are NAs in the columns used for filtering in `transition_filter`, possible error:
```
Error in `$<-.data.frame`(`*tmp*`, "colour", value = "grey") :
  replacement has 1 row, data has 0
```

Issue tracks down to an `if()` clause in the `assign_filters()` function.

## SOLUTION:
add `na.rm = TRUE` to the if clause argument