### PR TITLE
Correcting docs for nframes and fps arguments

### DIFF
--- a/vignettes/gganimate.Rmd
+++ b/vignettes/gganimate.Rmd
@@ -225,8 +225,8 @@ when you ask *gganimate* to render the animation. When you print an animation
 object the `animate()` function is called on the animation with default 
 arguments, some of which are:
 
-- **nframes** sets the number of frames (defaults to `100`)
-- **fps** sets the number of frames (defaults to `10`)
+- **nframes** sets the number of frames to render (defaults to `100`)
+- **fps** sets the frame rate of the animation in frames/sec (defaults to `10`)
 - **dev** sets the device used to render each frame (defaults to `'png'`)
 - **renderer** sets the function used to combine each frame into an animate 
   (defaults to `gifski_renderer()`)


### PR DESCRIPTION
Correcting docs for nframes and fps arguments of the animate function. Making them consistent with documentation of `animate`