### PR TITLE
Fix guides with ggplot2 3.5.0

### DIFF
--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -94,10 +94,18 @@ ggplot_build.gganim <- function(plot) {
   layout$setup_panel_params()
   data <- layout$map_position(data)
 
+  new_guides <- inherits(plot$guides, "Guides")
+  if (new_guides) {
+    layout$setup_panel_guides(plot$guides, plot$layers)
+  }
+
   # Train and map non-position scales
   npscales <- scales$non_position_scales()
   if (npscales$n() > 0) {
     lapply(data, npscales$train_df)
+    if (new_guides) {
+      plot$guides <- plot$guides$build(npscales, plot$layers, plot$labels, data)
+    }
     data <- lapply(data, npscales$map_df)
   }
 

--- a/R/view-.R
+++ b/R/view-.R
@@ -48,6 +48,9 @@ View <- ggproto('View', NULL,
       # We need to do it twice because CoordFlip flips the scales in-place
       plot$layout$setup_panel_params()
     }
+    if (inherits(plot$plot$guides, "Guides")) {
+      plot$layout$setup_panel_guides(plot$plot$guides, plot$plot$layers)
+    }
     plot
   },
   get_ranges = function(self, data, params) {


### PR DESCRIPTION
This PR aims to fix #489.

Demo that the guides are present:

``` r
devtools::load_all("~/packages/test/gganimate/")
#> ℹ Loading gganimate
#> Loading required package: ggplot2

ggplot(mtcars, aes(factor(cyl), mpg)) + 
  geom_boxplot(aes(fill = factor(cyl))) + 
  transition_states(
    gear,
    transition_length = 2,
    state_length = 1
  ) +
  enter_fade() + 
  exit_shrink() +
  ease_aes('sine-in-out')
```

![](https://i.imgur.com/FogXDPQ.gif)<!-- -->

<sup>Created on 2024-02-12 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

I also found that that 'rolling limits' had to re-render the axis guides, so that is adressed here as well. Demo:

```r
ggplot(economics, aes(as.numeric(date), unemploy)) +
  geom_line() +
  view_zoom_manual(
    0, 1, ease = "linear", wrap = FALSE,
    xmin = as.numeric(seq(as.Date("1970-01-01"), as.Date("2010-01-01"), length.out = 10)),
    xmax = as.numeric(seq(as.Date("1980-01-01"), as.Date("2020-01-01"), length.out = 10)),
    ymin = min(economics$unemploy),
    ymax = max(economics$unemploy)
  )
```

![](https://i.imgur.com/8FN4Un5.gif)<!-- -->
