### PR TITLE
Adapt to new theming in ggplot2

### DIFF
--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -94,6 +94,12 @@ ggplot_build.gganim <- function(plot) {
   layout$setup_panel_params()
   data <- layout$map_position(data)
 
+  complete_theme <- get0("complete_theme", asNamespace("ggplot2"))
+  new_theme <- is.function(complete_theme)
+  if (new_theme) {
+    plot$theme <- complete_theme(plot$theme)
+  }
+
   new_guides <- inherits(plot$guides, "Guides")
   if (new_guides) {
     layout$setup_panel_guides(plot$guides, plot$layers)

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -108,15 +108,26 @@ ggplot_build.gganim <- function(plot) {
   # Train and map non-position scales
   npscales <- scales$non_position_scales()
   if (npscales$n() > 0) {
-    lapply(data, npscales$train_df)
-    if (new_guides) {
+    if (new_theme) {
+      npscales$set_palettes(plot$theme)
+      lapply(data, npscales$train_df)
+      plot$guides <- plot$guides$build(npscales, plot$layers, plot$labels, data, plot$theme)
+    } else if (new_guides) {
+      lapply(data, npscales$train_df)
       plot$guides <- plot$guides$build(npscales, plot$layers, plot$labels, data)
     }
     data <- lapply(data, npscales$map_df)
   }
 
   # Fill in defaults etc.
-  data <- by_layer(function(l, d) l$compute_geom_2(d), layers, data, "setting up geom aesthetics")
+  if (new_theme) {
+    data <- by_layer(
+      function(l, d) l$compute_geom_2(d, theme = plot$theme),
+      layers, data, "setting up geom_aesthetics"
+    )
+  } else {
+    data <- by_layer(function(l, d) l$compute_geom_2(d), layers, data, "setting up geom aesthetics")
+  }
 
   # gganimate
   data <- scene$after_defaults(data)

--- a/R/plot-build.R
+++ b/R/plot-build.R
@@ -115,6 +115,8 @@ ggplot_build.gganim <- function(plot) {
     } else if (new_guides) {
       lapply(data, npscales$train_df)
       plot$guides <- plot$guides$build(npscales, plot$layers, plot$labels, data)
+    } else {
+      lapply(data, npscales$train_df)
     }
     data <- lapply(data, npscales$map_df)
   }


### PR DESCRIPTION
This PR aims to fix an issue identified in https://github.com/tidyverse/ggplot2/pull/6287.

Briefly, it incorporates recent changes to ggplot2 themes into gganimate's build method.

As an example (I'm sorry for the default windows GD 😁):

``` r
devtools::load_all("~/packages/ggplot2/")
#> ℹ Loading ggplot2
devtools::load_all("~/packages/test/gganimate/")
#> ℹ Loading gganimate

p <- ggplot(iris, aes(x = Petal.Width, y = Petal.Length, size = Sepal.Width)) + 
  geom_point() +
  theme_gray(ink = "white", paper = "black")

anim <- p + 
  transition_states(Species,
                    transition_length = 2,
                    state_length = 1)

anim
```

![](https://i.imgur.com/Migq6VQ.gif)<!-- -->

<sup>Created on 2025-01-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
