### PR TITLE
Use `base::is.expression()` to determine expression-ness

### DIFF
--- a/R/scene.R
+++ b/R/scene.R
@@ -158,7 +158,7 @@ Scene <- ggproto('Scene', NULL,
       })
       if (orig_call) {
         new_label[[1]]
-      } else if (is_expression(label)) {
+      } else if (is.expression(label)) {
         as.expression(new_label)
       } else {
         unlist(new_label)


### PR DESCRIPTION
This PR aims to fix https://github.com/r-lib/marquee/issues/76.

Essentially `rlang::is_expression()` treats strings as expressions, which we don't need.
I couldn't find a reason in the commit history other than 'use more rlang functions' for this, so I hope I'm prancing around Chesterton's fence.
Reprex from the issue:

``` r
devtools::load_all("~/packages/test/gganimate/")
#> ℹ Loading gganimate
#> Loading required package: ggplot2
library(ggplot2)
library(marquee)

anim <- ggplot(economics, aes(date, unemploy)) + 
  geom_line() + 
  labs(title = "Unemployment") + 
  theme(plot.title = element_marquee()) + 
  transition_reveal(date)

# avoid hurting the poor eyes with windows png device
animate(anim, device = "ragg_png")
```

![](https://i.imgur.com/Y0WcvkJ.gif)<!-- -->

<sup>Created on 2025-06-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
